### PR TITLE
Streamline laskenta if handling an empty set

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>fi.vm.sade.valintaperusteet</groupId>
     <artifactId>valintaperusteet</artifactId>
-    <version>5.3-SNAPSHOT</version>
+    <version>5.4-SNAPSHOT</version>
 
     <name>Valintaperusteet</name>
     <packaging>pom</packaging>

--- a/valintaperusteet-api/pom.xml
+++ b/valintaperusteet-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>valintaperusteet</artifactId>
 		<groupId>fi.vm.sade.valintaperusteet</groupId>
-		<version>5.3-SNAPSHOT</version>
+		<version>5.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	

--- a/valintaperusteet-domain/pom.xml
+++ b/valintaperusteet-domain/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
         <artifactId>valintaperusteet</artifactId>
-		<version>5.3-SNAPSHOT</version>
+		<version>5.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>valintaperusteet-domain</artifactId>

--- a/valintaperusteet-laskenta/pom.xml
+++ b/valintaperusteet-laskenta/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
         <artifactId>valintaperusteet</artifactId>
-        <version>5.3-SNAPSHOT</version>
+        <version>5.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/valintaperusteet-service/pom.xml
+++ b/valintaperusteet-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
         <artifactId>valintaperusteet</artifactId>
-        <version>5.3-SNAPSHOT</version>
+        <version>5.4-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 


### PR DESCRIPTION
Huomataan, jos ollaan hakemassa arvoa tyhjästä joukosta ja oikaistaan. Käytännön vaikutusta on etupäässä spekulatiivisiin yo-arvosanatarkistuksiin, joita ei välttämättä löydy (ja se on ihan ok).

Tämän optimoinnin käyttöönotto vaatii tämän nostetun version käyttöönottoa valintalaskentanassa.