### PR TITLE
BUG-2098  jono prioriteetti

### DIFF
--- a/valintaperusteet-service/src/main/java/fi/vm/sade/service/valintaperusteet/dto/mapping/ValintaperusteetModelMapper.java
+++ b/valintaperusteet-service/src/main/java/fi/vm/sade/service/valintaperusteet/dto/mapping/ValintaperusteetModelMapper.java
@@ -226,9 +226,14 @@ public class ValintaperusteetModelMapper extends ModelMapper {
         });
 
         this.addMappings(new PropertyMap<Valintatapajono, ValintatapajonoDTO>() {
+            // huom: prioriteetti jää tässä tyhjäksi yksittäiselle valintatapajonolle, jolloin
+            // se saa default-arvon eli 0. Prioriteetit lisätään vain mapList-metodissa alla.
+            // Asetetaan tässä arvoksi -1 sen merkiksi että kyseessä ei ole todellinen prioriteetti.
+
             @Override
             protected void configure() {
                 map().setTayttojono(source.getVarasijanTayttojono().getOid());
+                map().setPrioriteetti(-1);
             }
         });
 

--- a/valintaperusteet-service/src/test/java/fi/vm/sade/service/valintaperusteet/resource/ValintatapajonoResourceTest.java
+++ b/valintaperusteet-service/src/test/java/fi/vm/sade/service/valintaperusteet/resource/ValintatapajonoResourceTest.java
@@ -1,10 +1,8 @@
 package fi.vm.sade.service.valintaperusteet.resource;
 
 import fi.vm.sade.service.valintaperusteet.annotation.DataSetLocation;
-import fi.vm.sade.service.valintaperusteet.dto.JarjestyskriteeriCreateDTO;
-import fi.vm.sade.service.valintaperusteet.dto.JarjestyskriteeriDTO;
-import fi.vm.sade.service.valintaperusteet.dto.JarjestyskriteeriInsertDTO;
-import fi.vm.sade.service.valintaperusteet.dto.ValintatapajonoDTO;
+import fi.vm.sade.service.valintaperusteet.dto.*;
+import fi.vm.sade.service.valintaperusteet.dto.mapping.ValintaperusteetModelMapper;
 import fi.vm.sade.service.valintaperusteet.listeners.ValinnatJTACleanInsertTestExecutionListener;
 import fi.vm.sade.service.valintaperusteet.model.JsonViews;
 import fi.vm.sade.service.valintaperusteet.resource.impl.ValinnanVaiheResourceImpl;
@@ -35,6 +33,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.eq;
@@ -202,6 +202,19 @@ public class ValintatapajonoResourceTest {
         assertEquals("5", jarjesta.get(0).getOid());
         assertEquals("1", jarjesta.get(4).getOid());
     }
+
+
+    @Test
+    public void testPrioriteettiOfSingleJonoIsAlwaysZero() throws Exception {
+        ValintaperusteetModelMapper modelMapper = new ValintaperusteetModelMapper();
+
+        List<String> allOids = resource.findAll().stream().map(ValintatapajonoDTO::getOid).collect(Collectors.toList());
+        allOids.stream().forEach(oid -> {
+            ValintatapajonoDTO dto = modelMapper.map(resource.readByOid(oid), ValintatapajonoDTO.class);
+            assertEquals(0, dto.getPrioriteetti());
+        });
+    }
+
 }
 
 @Configuration

--- a/valintaperusteet-service/src/test/java/fi/vm/sade/service/valintaperusteet/resource/ValintatapajonoResourceTest.java
+++ b/valintaperusteet-service/src/test/java/fi/vm/sade/service/valintaperusteet/resource/ValintatapajonoResourceTest.java
@@ -205,14 +205,26 @@ public class ValintatapajonoResourceTest {
 
 
     @Test
-    public void testPrioriteettiOfSingleJonoIsAlwaysZero() throws Exception {
+    public void testPrioriteettiOfSingleJonoHasCustomDefault() throws Exception {
         ValintaperusteetModelMapper modelMapper = new ValintaperusteetModelMapper();
 
         List<String> allOids = resource.findAll().stream().map(ValintatapajonoDTO::getOid).collect(Collectors.toList());
         allOids.stream().forEach(oid -> {
             ValintatapajonoDTO dto = modelMapper.map(resource.readByOid(oid), ValintatapajonoDTO.class);
-            assertEquals(0, dto.getPrioriteetti());
+            assertEquals(-1, dto.getPrioriteetti());
         });
+    }
+
+    @Test
+    public void testPrioriteettiOfSeveralJonosInOrder() throws Exception {
+        ValintaperusteetModelMapper modelMapper = new ValintaperusteetModelMapper();
+
+        List<ValintatapajonoDTO> all = resource.findAll();
+
+        for (int i = 0; i < all.size(); i++) {
+            ValintatapajonoDTO dto = modelMapper.map(all.get(i), ValintatapajonoDTO.class);
+            assertEquals(i, dto.getPrioriteetti());
+        }
     }
 
 }


### PR DESCRIPTION
Ongelma: kun siirretään jono sijoitteluun/pois sijoittelusta, sen prioriteetiksi muuttuu aina 0.

Tämän syy oli siinä, että valintaperusteet-service palauttaa aina yhtä jonoa kysyessä sen prioriteetille default-arvon 0. (Prioriteeteille palautuu ei-nollia arvoja vain kun kysytään useita jonoja.) Tämä uusi arvo sitten tallentuu kun asetetaan jono sijoiteltavaksi.

Korjataan nyt niin, että laitetaan valintaperusteet-service palauttamaan defaulttina yksittäiselle jonolle prioriteetiksi -1, jotta on selvää ettei kyse ole todellisesta prioriteetista. Sitten (ks. https://github.com/Opetushallitus/valintalaskenta-ui/pull/22 ) tallennetaan -1:n sijaan UI:n muistissa oleva prioriteetti.