### PR TITLE
VTKU-147 Jos-funktio oletuksena ahneeksi (eli ennalleen)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,11 +46,6 @@ deploy:
   on:
     branch: master
 - provider: script
-  script: mvn deploy -pl fi.vm.sade.valintaperusteet:valintaperusteet,valintaperusteet-domain,valintaperusteet-api,valintaperusteet-laskenta -DskipTests --settings ci-tools/common/maven-settings.xml
-  skip_cleanup: true
-  on:
-    branch: VTKU-147__jos-funktio_oletuksena_ahneeksi
-- provider: script
   script: ./ci-tools/build/upload-image.sh $ARTIFACT_NAME
   on:
     all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,11 @@ deploy:
   on:
     branch: master
 - provider: script
+  script: mvn deploy -pl fi.vm.sade.valintaperusteet:valintaperusteet,valintaperusteet-domain,valintaperusteet-api,valintaperusteet-laskenta -DskipTests --settings ci-tools/common/maven-settings.xml
+  skip_cleanup: true
+  on:
+    branch: VTKU-147__jos-funktio_oletuksena_ahneeksi
+- provider: script
   script: ./ci-tools/build/upload-image.sh $ARTIFACT_NAME
   on:
     all_branches: true

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>fi.vm.sade.valintaperusteet</groupId>
     <artifactId>valintaperusteet</artifactId>
-    <version>5.11-SNAPSHOT</version>
+    <version>5.12-VTKU-147-SNAPSHOT</version>
 
     <name>Valintaperusteet</name>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>fi.vm.sade.valintaperusteet</groupId>
     <artifactId>valintaperusteet</artifactId>
-    <version>5.12-VTKU-147-SNAPSHOT</version>
+    <version>5.12-SNAPSHOT</version>
 
     <name>Valintaperusteet</name>
     <packaging>pom</packaging>

--- a/valintaperusteet-api/pom.xml
+++ b/valintaperusteet-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>valintaperusteet</artifactId>
 		<groupId>fi.vm.sade.valintaperusteet</groupId>
-		<version>5.11-SNAPSHOT</version>
+		<version>5.12-VTKU-147-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	

--- a/valintaperusteet-api/pom.xml
+++ b/valintaperusteet-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>valintaperusteet</artifactId>
 		<groupId>fi.vm.sade.valintaperusteet</groupId>
-		<version>5.12-VTKU-147-SNAPSHOT</version>
+		<version>5.12-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	

--- a/valintaperusteet-api/src/main/java/fi/vm/sade/service/valintaperusteet/dto/model/Funktionimi.java
+++ b/valintaperusteet-api/src/main/java/fi/vm/sade/service/valintaperusteet/dto/model/Funktionimi.java
@@ -64,6 +64,7 @@ public enum Funktionimi {
     HAEAMMATILLISENTUTKINNONKESKIARVO("Ammatillisen tutkinnon tallennettu keskiarvo", Funktiotyyppi.LUKUARVOFUNKTIO, Laskentamoodi.VALINTALASKENTA, Laskentamoodi.VALINTAKOELASKENTA),
     HAEAMMATILLISENTUTKINNONSUORITUSTAPA("Ammatillisen tutkinnon suoritustapa", Funktiotyyppi.LUKUARVOFUNKTIO, Laskentamoodi.VALINTALASKENTA, Laskentamoodi.VALINTAKOELASKENTA);
 
+    public static final String JOS_LAISKA_PARAMETRI = "laskeLaiskasti";
 
     private final String kuvaus;
     private Funktiotyyppi tyyppi;

--- a/valintaperusteet-domain/pom.xml
+++ b/valintaperusteet-domain/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
         <artifactId>valintaperusteet</artifactId>
-		<version>5.12-VTKU-147-SNAPSHOT</version>
+		<version>5.12-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>valintaperusteet-domain</artifactId>

--- a/valintaperusteet-domain/pom.xml
+++ b/valintaperusteet-domain/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
         <artifactId>valintaperusteet</artifactId>
-		<version>5.11-SNAPSHOT</version>
+		<version>5.12-VTKU-147-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>valintaperusteet-domain</artifactId>

--- a/valintaperusteet-laskenta/pom.xml
+++ b/valintaperusteet-laskenta/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
         <artifactId>valintaperusteet</artifactId>
-        <version>5.12-VTKU-147-SNAPSHOT</version>
+        <version>5.12-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/valintaperusteet-laskenta/pom.xml
+++ b/valintaperusteet-laskenta/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
         <artifactId>valintaperusteet</artifactId>
-        <version>5.11-SNAPSHOT</version>
+        <version>5.12-VTKU-147-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/valintaperusteet-laskenta/src/main/scala/fi/vm/sade/kaava/Funktiokuvaaja.scala
+++ b/valintaperusteet-laskenta/src/main/scala/fi/vm/sade/kaava/Funktiokuvaaja.scala
@@ -1,6 +1,7 @@
 package fi.vm.sade.kaava
 
 import fi.vm.sade.service.valintaperusteet.dto.model.Funktionimi
+import fi.vm.sade.service.valintaperusteet.dto.model.Funktionimi.JOS_LAISKA_PARAMETRI
 import play.api.libs.json.JsArray
 import play.api.libs.json.Json
 
@@ -400,7 +401,13 @@ object Funktiokuvaaja {
       tyyppi = Funktiotyyppi.LUKUARVOFUNKTIO,
       funktioargumentit = List(Funktioargumenttikuvaus("ehto", Funktiotyyppi.TOTUUSARVOFUNKTIO),
         Funktioargumenttikuvaus("sitten", Funktiotyyppi.LUKUARVOFUNKTIO),
-        Funktioargumenttikuvaus("muuten", Funktiotyyppi.LUKUARVOFUNKTIO))
+        Funktioargumenttikuvaus("muuten", Funktiotyyppi.LUKUARVOFUNKTIO)),
+      syoteparametrit = List(
+        Syoteparametrikuvaus(
+          JOS_LAISKA_PARAMETRI,
+          Syoteparametrityyppi.CHECKBOX,
+          pakollinen = false,
+          kuvaus = "Lasketaanko vain se haara, jonka arvo lopulta palautetaan"))
     ),
     Funktionimi.KESKIARVO -> Funktiokuvaus(
       tyyppi = Funktiotyyppi.LUKUARVOFUNKTIO,

--- a/valintaperusteet-laskenta/src/main/scala/fi/vm/sade/kaava/Laskentadomainkonvertteri.scala
+++ b/valintaperusteet-laskenta/src/main/scala/fi/vm/sade/kaava/Laskentadomainkonvertteri.scala
@@ -3,6 +3,7 @@ package fi.vm.sade.kaava
 import java.util.{Set => JSet}
 
 import fi.vm.sade.service.valintaperusteet.dto.model.Funktionimi
+import fi.vm.sade.service.valintaperusteet.dto.model.Funktionimi.JOS_LAISKA_PARAMETRI
 import fi.vm.sade.service.valintaperusteet.dto.model.Valintaperustelahde
 import fi.vm.sade.service.valintaperusteet.laskenta.Funktio
 import fi.vm.sade.service.valintaperusteet.laskenta.Laskenta.ArvokonversioMerkkijonoilla
@@ -308,11 +309,13 @@ object Laskentadomainkonvertteri {
       case Funktionimi.JA =>
         Ja(lasketutArgumentit.map(muunnaTotuusarvofunktioksi(_)), oid, tulosTunniste, tulosTekstiFi, tulosTekstiSv, tulosTekstiEn, omaopintopolku)
 
-      case Funktionimi.JOS => Jos(
-        muunnaTotuusarvofunktioksi(lasketutArgumentit(0)),
-        muunnaLukuarvofunktioksi(lasketutArgumentit(1)),
-        muunnaLukuarvofunktioksi(lasketutArgumentit(2)),
-        oid, tulosTunniste, tulosTekstiFi, tulosTekstiSv, tulosTekstiEn, omaopintopolku = omaopintopolku)
+      case Funktionimi.JOS =>
+        Jos(
+          syoteparametrit.asScala.find(_.getAvain == JOS_LAISKA_PARAMETRI).filter(p => StringUtils.isNotBlank(p.getArvo)).exists(parametriToBoolean),
+          muunnaTotuusarvofunktioksi(lasketutArgumentit(0)),
+          muunnaLukuarvofunktioksi(lasketutArgumentit(1)),
+          muunnaLukuarvofunktioksi(lasketutArgumentit(2)),
+          oid, tulosTunniste, tulosTekstiFi, tulosTekstiSv, tulosTekstiEn, omaopintopolku = omaopintopolku)
 
       case Funktionimi.KESKIARVO =>
         Keskiarvo(lasketutArgumentit.map(muunnaLukuarvofunktioksi(_)), oid, tulosTunniste, tulosTekstiFi, tulosTekstiSv, tulosTekstiEn, omaopintopolku)
@@ -507,7 +510,7 @@ object Laskentadomainkonvertteri {
           omaopintopolku = omaopintopolku)
 
         val arvosana = if (ehdot.vainValmistuneet) {
-          Jos(HaeTotuusarvo(None, Some(false), HakemuksenValintaperuste(YO + TILA_SUFFIX, false), omaopintopolku = omaopintopolku),
+          Jos(laskeHaaratLaiskasti = false, HaeTotuusarvo(None, Some(false), HakemuksenValintaperuste(YO + TILA_SUFFIX, false), omaopintopolku = omaopintopolku),
             arvosanaFunktio,
             Lukuarvo(BigDecimal("0.0"), omaopintopolku = omaopintopolku),
             omaopintopolku = omaopintopolku)
@@ -531,7 +534,7 @@ object Laskentadomainkonvertteri {
           omaopintopolku = omaopintopolku)
 
         val arvosana = if (ehdot.vainValmistuneet) {
-          Jos(HaeTotuusarvo(None, Some(false), HakemuksenValintaperuste(YO + TILA_SUFFIX, false), omaopintopolku = omaopintopolku),
+          Jos(laskeHaaratLaiskasti = false, HaeTotuusarvo(None, Some(false), HakemuksenValintaperuste(YO + TILA_SUFFIX, false), omaopintopolku = omaopintopolku),
             arvosanaFunktio, Lukuarvo(BigDecimal("0.0"), omaopintopolku = omaopintopolku),
             omaopintopolku = omaopintopolku)
         } else {

--- a/valintaperusteet-laskenta/src/main/scala/fi/vm/sade/service/valintaperusteet/laskenta/Laskenta.scala
+++ b/valintaperusteet-laskenta/src/main/scala/fi/vm/sade/service/valintaperusteet/laskenta/Laskenta.scala
@@ -259,7 +259,16 @@ object Laskenta {
     }
   }
 
-  case class Jos(ehto: Totuusarvofunktio, ifHaara: Lukuarvofunktio, elseHaara: Lukuarvofunktio, oid: String = "", tulosTunniste: String = "", tulosTekstiFi: String = "", tulosTekstiSv: String = "", tulosTekstiEn: String = "", omaopintopolku: Boolean = false)
+  case class Jos(laskeHaaratLaiskasti: Boolean,
+                 ehto: Totuusarvofunktio,
+                 ifHaara: Lukuarvofunktio,
+                 elseHaara: Lukuarvofunktio,
+                 oid: String = "",
+                 tulosTunniste: String = "",
+                 tulosTekstiFi: String = "",
+                 tulosTekstiSv: String = "",
+                 tulosTekstiEn: String = "",
+                 omaopintopolku: Boolean = false)
     extends Lukuarvofunktio
 
   sealed trait HaeArvo[T] extends Funktio[T] {

--- a/valintaperusteet-laskenta/src/main/scala/fi/vm/sade/service/valintaperusteet/laskenta/LukuarvoLaskin.scala
+++ b/valintaperusteet-laskenta/src/main/scala/fi/vm/sade/service/valintaperusteet/laskenta/LukuarvoLaskin.scala
@@ -262,7 +262,7 @@ protected[laskenta] class LukuarvoLaskin(protected val laskin: Laskin)
         })
         (tulos, tilat, Historia(MEDIAANI, tulos, tilat, h.historiat, None))
 
-      case Jos(laskeHaaratLaiskasti, ehto, thenHaara, elseHaara, _, _, _, _, _, _) =>
+      case Jos(laskeHaaratLaiskasti, ehto, thenHaara, elseHaara, _, tulosTunniste, tulosTekstiFi, _, _, _) =>
         val ehtoTulos = new TotuusarvoLaskin(this.laskin).laskeTotuusarvo(ehto, iteraatioParametrit)
         val (tulos, tilat, historia) = ehdollinenTulos[Boolean, (Option[BigDecimal], List[Tila], List[Historia])]((ehtoTulos.tulos, ehtoTulos.tila), (cond, tila) => {
           if (cond) {
@@ -271,7 +271,16 @@ protected[laskenta] class LukuarvoLaskin(protected val laskin: Laskin)
             laskeTarvittavatJosTulokset(iteraatioParametrit, laskeHaaratLaiskasti, elseHaara, thenHaara, tila)
           }
         }, (None, List(ehtoTulos.tila), Nil))
-        (tulos, tilat, Historia(JOS, tulos, tilat, Some(List(ehtoTulos.historia) ++ historia), None))
+        val avaimet: Option[Map[String, Option[Any]]] = if (StringUtils.isNotBlank(tulosTunniste)) {
+          Some(Map(
+            tulosTekstiFi + ": laske vain tarvittavan haaran arvo" -> Option(laskeHaaratLaiskasti),
+            tulosTekstiFi + ": ehtotulos" -> Option(ehtoTulos.tulos),
+            tulosTekstiFi + ": paluuarvo" -> Option(tulos)))
+        } else {
+          None
+        }
+
+        (tulos, tilat, Historia(JOS, tulos, tilat, Some(List(ehtoTulos.historia) ++ historia), avaimet))
 
       case KonvertoiLukuarvo(konvertteri, f, _, _,tulosTekstiFi,_,_,_) =>
         laskeLukuarvo(f, iteraatioParametrit) match {

--- a/valintaperusteet-laskenta/src/test/scala/fi/vm/sade/service/valintaperusteet/laskenta/AmmatillisetArvosanatLaskentaTest.scala
+++ b/valintaperusteet-laskenta/src/test/scala/fi/vm/sade/service/valintaperusteet/laskenta/AmmatillisetArvosanatLaskentaTest.scala
@@ -6,10 +6,15 @@ import java.util.{List => JList}
 import java.util.{Map => JMap}
 
 import fi.vm.sade.kaava.LaskentaTestUtil.TestHakemus
-import fi.vm.sade.kaava.{LaskentaTestUtil, Laskentadomainkonvertteri}
+import fi.vm.sade.kaava.LaskentaTestUtil
+import fi.vm.sade.kaava.Laskentadomainkonvertteri
 import fi.vm.sade.service.valintaperusteet.dto.model.Funktionimi
+import fi.vm.sade.service.valintaperusteet.dto.model.Funktionimi.JOS_LAISKA_PARAMETRI
 import fi.vm.sade.service.valintaperusteet.laskenta.api.Hakukohde
-import fi.vm.sade.service.valintaperusteet.model.{Arvokonvertteriparametri, Funktiokutsu, TekstiRyhma}
+import fi.vm.sade.service.valintaperusteet.model.Syoteparametri
+import fi.vm.sade.service.valintaperusteet.model.Arvokonvertteriparametri
+import fi.vm.sade.service.valintaperusteet.model.Funktiokutsu
+import fi.vm.sade.service.valintaperusteet.model.TekstiRyhma
 import io.circe.Json
 import io.circe.parser
 import org.scalatest.funsuite.AnyFunSuite
@@ -218,10 +223,14 @@ class AmmatillisetArvosanatLaskentaTest extends AnyFunSuite {
     }
 
     def jos(totuusarvo: Funktiokutsu, haara1: Funktiokutsu, haara2: Funktiokutsu): Funktiokutsu = {
+      val josLaiskaksi: Syoteparametri = new Syoteparametri()
+      josLaiskaksi.setAvain(JOS_LAISKA_PARAMETRI)
+      josLaiskaksi.setArvo(true.toString)
       LaskentaTestUtil.Funktiokutsu(
         nimi = Funktionimi.JOS,
         funktioargumentit = List(
-          totuusarvo, haara1, haara2))
+          totuusarvo, haara1, haara2),
+        syoteparametrit = List(josLaiskaksi))
     }
 
     def yhtasuuri(haara1: Funktiokutsu, haara2: Funktiokutsu): Funktiokutsu = {

--- a/valintaperusteet-laskenta/src/test/scala/fi/vm/sade/service/valintaperusteet/laskenta/LaskentaTest.scala
+++ b/valintaperusteet-laskenta/src/test/scala/fi/vm/sade/service/valintaperusteet/laskenta/LaskentaTest.scala
@@ -302,7 +302,7 @@ class LaskentaTest extends AnyFunSuite {
     val ifHaara = Lukuarvo(100.0)
     val elseHaara = Lukuarvo(500.0)
 
-    val ifLause = Jos(ehto, ifHaara, elseHaara)
+    val ifLause = Jos(laskeHaaratLaiskasti = false, ehto, ifHaara, elseHaara)
 
     val (tulos, _) = Laskin.laske(hakukohde, tyhjaHakemus, ifLause)
     assert(BigDecimal(tulos.get) == BigDecimal(500.0))
@@ -313,11 +313,22 @@ class LaskentaTest extends AnyFunSuite {
     val toimivaHaara = Lukuarvo(BigDecimal(100))
     val kaatuvaHaara = HaeLukuarvo(None, None, HakemuksenValintaperuste("jotain minkä hakeminen null-hakemukselta kaatuisi", false))
 
-    val tosiJos = Jos(Totuusarvo(true), toimivaHaara, kaatuvaHaara)
-    val epatosiJos = Jos(Totuusarvo(false), kaatuvaHaara, toimivaHaara)
+    val tosiJos = Jos(laskeHaaratLaiskasti = true, Totuusarvo(true), toimivaHaara, kaatuvaHaara)
+    val epatosiJos = Jos(laskeHaaratLaiskasti = true, Totuusarvo(false), kaatuvaHaara, toimivaHaara)
 
     assert(Laskin.laske(hakukohde, null, tosiJos)._1.contains(new java.math.BigDecimal(100)))
     assert(Laskin.laske(hakukohde, null, epatosiJos)._1.contains(new java.math.BigDecimal(100)))
+  }
+
+  test("Ahne Jos") {
+    val toimivaHaara = Lukuarvo(BigDecimal(100))
+    val kaatuvaHaara = HaeLukuarvo(None, None, HakemuksenValintaperuste("jotain minkä hakeminen null-hakemukselta kaatuisi", false))
+
+    val tosiJos = Jos(laskeHaaratLaiskasti = false, Totuusarvo(true), toimivaHaara, kaatuvaHaara)
+    val epatosiJos = Jos(laskeHaaratLaiskasti = false, Totuusarvo(false), kaatuvaHaara, toimivaHaara)
+
+    assertThrows[NullPointerException](Laskin.laske(hakukohde, null, tosiJos))
+    assertThrows[NullPointerException](Laskin.laske(hakukohde, null, epatosiJos))
   }
 
   test("Totuusarvo") {
@@ -689,6 +700,7 @@ class LaskentaTest extends AnyFunSuite {
           )
         ),
         Jos(
+          laskeHaaratLaiskasti = false,
           ehto = HaeMerkkijonoJaVertaaYhtasuuruus(
             oletusarvo = None,
             valintaperusteviite = SyotettavaValintaperuste(

--- a/valintaperusteet-service/pom.xml
+++ b/valintaperusteet-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
         <artifactId>valintaperusteet</artifactId>
-        <version>5.12-VTKU-147-SNAPSHOT</version>
+        <version>5.12-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/valintaperusteet-service/pom.xml
+++ b/valintaperusteet-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
         <artifactId>valintaperusteet</artifactId>
-        <version>5.11-SNAPSHOT</version>
+        <version>5.12-VTKU-147-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/valintaperusteet-testing/pom.xml
+++ b/valintaperusteet-testing/pom.xml
@@ -7,18 +7,18 @@
     <parent>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
         <artifactId>valintaperusteet</artifactId>
-        <version>5.11-SNAPSHOT</version>
+        <version>5.12-VTKU-147-SNAPSHOT</version>
     </parent>
 
     <groupId>fi.vm.sade.valintaperusteet</groupId>
     <artifactId>valintaperusteet-testing</artifactId>
-    <version>5.11-SNAPSHOT</version>
+    <version>5.12-VTKU-147-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
             <groupId>fi.vm.sade.valintaperusteet</groupId>
             <artifactId>valintaperusteet-service</artifactId>
-            <version>5.11-SNAPSHOT</version>
+            <version>5.12-VTKU-147-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/valintaperusteet-testing/pom.xml
+++ b/valintaperusteet-testing/pom.xml
@@ -7,18 +7,18 @@
     <parent>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
         <artifactId>valintaperusteet</artifactId>
-        <version>5.12-VTKU-147-SNAPSHOT</version>
+        <version>5.12-SNAPSHOT</version>
     </parent>
 
     <groupId>fi.vm.sade.valintaperusteet</groupId>
     <artifactId>valintaperusteet-testing</artifactId>
-    <version>5.12-VTKU-147-SNAPSHOT</version>
+    <version>5.12-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
             <groupId>fi.vm.sade.valintaperusteet</groupId>
             <artifactId>valintaperusteet-service</artifactId>
-            <version>5.12-VTKU-147-SNAPSHOT</version>
+            <version>5.12-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Joitakin raportointeja varten tarvitsee evaluoida myös se Jos-funktion haara, jonka arvoa ei palauteta Jos-funktion paluuarvona.

Nyt voi kuitenkin parametrilla tehdä halutessaan Jos-funktiosta laiskan, mikä taas parantaa ammatillisten arvosanojen käytön raportointia (esim jos tutkinnolle löytyy tallennettu keskiarvo, ei ruveta itse laskemaan keskiarvoa tutkinnon osista).