### PR TITLE
Muuta valintaryhmän valintaa

### DIFF
--- a/valintaperusteet-service/src/main/java/fi/vm/sade/service/valintaperusteet/dao/ValintaryhmaDAO.java
+++ b/valintaperusteet-service/src/main/java/fi/vm/sade/service/valintaperusteet/dao/ValintaryhmaDAO.java
@@ -1,8 +1,8 @@
 package fi.vm.sade.service.valintaperusteet.dao;
 
 import fi.vm.sade.service.valintaperusteet.model.Valintaryhma;
-import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 public interface ValintaryhmaDAO extends JpaDAO<Valintaryhma, Long> {
   List<Valintaryhma> findChildrenByParentOid(String oid);
@@ -19,7 +19,7 @@ public interface ValintaryhmaDAO extends JpaDAO<Valintaryhma, Long> {
   Valintaryhma findAllFetchAlavalintaryhmat(String oid);
 
   List<Valintaryhma> haeHakukohdekoodinJaValintakoekoodienMukaan(
-      String hakukohdekoodiUri, Collection<String> valintakoekoodiUrit);
+      String hakuOid, String hakukohdekoodiUri, Set<String> valintakoekoodiUrit);
 
   List<Valintaryhma> readByHakukohdekoodiUri(String koodiUri);
 

--- a/valintaperusteet-service/src/main/java/fi/vm/sade/service/valintaperusteet/dao/impl/ValintaryhmaDAOImpl.java
+++ b/valintaperusteet-service/src/main/java/fi/vm/sade/service/valintaperusteet/dao/impl/ValintaryhmaDAOImpl.java
@@ -1,28 +1,29 @@
 package fi.vm.sade.service.valintaperusteet.dao.impl;
 
-import com.mysema.query.BooleanBuilder;
 import com.mysema.query.jpa.impl.JPAQuery;
 import com.mysema.query.types.EntityPath;
 import com.mysema.query.types.expr.BooleanExpression;
 import fi.vm.sade.service.valintaperusteet.dao.AbstractJpaDAOImpl;
 import fi.vm.sade.service.valintaperusteet.dao.ValintaryhmaDAO;
 import fi.vm.sade.service.valintaperusteet.model.QHakukohdekoodi;
-import fi.vm.sade.service.valintaperusteet.model.QValintakoekoodi;
 import fi.vm.sade.service.valintaperusteet.model.QValintaryhma;
 import fi.vm.sade.service.valintaperusteet.model.Valintaryhma;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class ValintaryhmaDAOImpl extends AbstractJpaDAOImpl<Valintaryhma, Long>
     implements ValintaryhmaDAO {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ValintaryhmaDAOImpl.class);
+  @Autowired private DataSource dataSource;
 
   protected JPAQuery from(EntityPath<?>... o) {
     return new JPAQuery(getEntityManager()).from(o);
@@ -141,26 +142,55 @@ public class ValintaryhmaDAOImpl extends AbstractJpaDAOImpl<Valintaryhma, Long>
 
   @Override
   public List<Valintaryhma> haeHakukohdekoodinJaValintakoekoodienMukaan(
-      String hakukohdekoodiUri, Collection<String> valintakoekoodiUrit) {
-    LOG.info(
-        "hakukohdekoodi: {}, valintakoekoodit: {}",
-        new Object[] {hakukohdekoodiUri, valintakoekoodiUrit});
-    QValintaryhma valintaryhma = QValintaryhma.valintaryhma;
-    QHakukohdekoodi hakukohdekoodi = QHakukohdekoodi.hakukohdekoodi;
-    QValintakoekoodi valintakoekoodi = QValintakoekoodi.valintakoekoodi;
-    BooleanBuilder booleanBuilder = new BooleanBuilder();
-    booleanBuilder.and(hakukohdekoodi.uri.eq(hakukohdekoodiUri));
-    if (!valintakoekoodiUrit.isEmpty()) {
-      booleanBuilder.and(valintakoekoodi.uri.in(valintakoekoodiUrit));
-    }
-    return from(valintaryhma)
-        .join(valintaryhma.hakukohdekoodit, hakukohdekoodi)
-        .fetch()
-        .leftJoin(valintaryhma.valintakoekoodit, valintakoekoodi)
-        .fetch()
-        .where(booleanBuilder)
-        .distinct()
-        .list(valintaryhma);
+      String hakuOid, String hakukohdekoodiUri, Set<String> valintakoekoodiUrit) {
+    List<String> oids =
+        new NamedParameterJdbcTemplate(this.dataSource)
+            .queryForList(
+                ""
+                    + "with recursive haun_ryhmat(id) as (\n"
+                    + "    select id\n"
+                    + "    from valintaryhma\n"
+                    + "    where hakuoid = :haku_oid\n"
+                    + "    union all\n"
+                    + "    select vr.id\n"
+                    + "    from haun_ryhmat\n"
+                    + "    join valintaryhma as vr\n"
+                    + "        on vr.parent_id = haun_ryhmat.id"
+                    + ")\n"
+                    + "select \"oid\"\n"
+                    + "from valintaryhma as vr\n"
+                    + "join valintaryhma_hakukohdekoodi as vr_hkk\n"
+                    + "    on vr_hkk.valintaryhma_id = vr.id\n"
+                    + "join hakukohdekoodi as hkk\n"
+                    + "    on hkk.id = vr_hkk.hakukohdekoodi_id\n"
+                    + "where vr.id in (select id from haun_ryhmat) and\n"
+                    + "      hkk.uri = :hakukohdekoodi and\n"
+                    + (valintakoekoodiUrit.isEmpty()
+                        ? "      not exists (select uri\n"
+                            + "                  from valintakoekoodi as vkk\n"
+                            + "                  join valintaryhma_valintakoekoodi as vr_vkk\n"
+                            + "                      on vr_vkk.valintakoekoodi_id = vkk.id\n"
+                            + "                  where vr_vkk.valintaryhma_id = vr.id)"
+                        : "      not exists (select uri\n"
+                            + "                  from valintakoekoodi as vkk\n"
+                            + "                  join valintaryhma_valintakoekoodi as vr_vkk\n"
+                            + "                      on vr_vkk.valintakoekoodi_id = vkk.id\n"
+                            + "                  where vr_vkk.valintaryhma_id = vr.id and\n"
+                            + "                        vkk.uri not in (:valintakoekoodit)) and"
+                            + "      not exists (select uri\n"
+                            + "                  from unnest(array[:valintakoekoodit ]) as t(uri)\n"
+                            + "                  except\n"
+                            + "                  select uri\n"
+                            + "                  from valintakoekoodi as vkk\n"
+                            + "                  join valintaryhma_valintakoekoodi as vr_vkk\n"
+                            + "                      on vr_vkk.valintakoekoodi_id = vkk.id\n"
+                            + "                  where vr_vkk.valintaryhma_id = vr.id)"),
+                new MapSqlParameterSource()
+                    .addValue("haku_oid", hakuOid)
+                    .addValue("hakukohdekoodi", hakukohdekoodiUri)
+                    .addValue("valintakoekoodit", valintakoekoodiUrit),
+                String.class);
+    return oids.stream().map(this::readByOid).collect(Collectors.toList());
   }
 
   private Valintaryhma findParent(String oid) {

--- a/valintaperusteet-service/src/main/java/fi/vm/sade/service/valintaperusteet/service/impl/HakukohdeImportServiceImpl.java
+++ b/valintaperusteet-service/src/main/java/fi/vm/sade/service/valintaperusteet/service/impl/HakukohdeImportServiceImpl.java
@@ -16,11 +16,11 @@ import fi.vm.sade.service.valintaperusteet.service.HakukohdeService;
 import fi.vm.sade.service.valintaperusteet.service.ValinnanVaiheService;
 import fi.vm.sade.service.valintaperusteet.service.ValintatapajonoService;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -157,105 +157,48 @@ public class HakukohdeImportServiceImpl implements HakukohdeImportService {
   }
 
   private Valintaryhma selvitaValintaryhma(HakukohdeImportDTO importData) {
-    LOG.info("Yritetään selvittää hakukohteen {} valintaryhmä", importData.getHakukohdeOid());
-    // Lasketaan valintakokeiden esiintymiset importtidatalle
-    Map<String, Integer> valintakoekoodiUrit = new HashMap<String, Integer>();
-    for (HakukohteenValintakoeDTO valintakoe : importData.getValintakoe()) {
-      final String valintakoeUri = sanitizeKoodiUri(valintakoe.getTyyppiUri());
-      if (StringUtils.isNotBlank(valintakoeUri)) {
-        if (!valintakoekoodiUrit.containsKey(valintakoeUri)) {
-          valintakoekoodiUrit.put(valintakoeUri, 0);
-        }
-        Integer esiintymat = valintakoekoodiUrit.get(valintakoeUri) + 1;
-        valintakoekoodiUrit.put(valintakoeUri, esiintymat);
-      }
-    }
-    // Haetaan potentiaaliset valintaryhmät hakukohdekoodin,
-    // opetuskielikoodien ja valintakoekoodien mukaan
+    String hakukohdeOid = importData.getHakukohdeOid();
+    String hakuOid = importData.getHakuOid();
+    String hakukohdekoodi = sanitizeKoodiUri(importData.getHakukohdekoodi().getKoodiUri());
+    Set<String> valintakoekoodit =
+        importData.getValintakoe().stream()
+            .map(valintakoe -> sanitizeKoodiUri(valintakoe.getTyyppiUri()))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    LOG.info("Yritetään selvittää hakukohteen {} valintaryhmä", hakukohdeOid);
+
     List<Valintaryhma> valintaryhmat =
         valintaryhmaDAO.haeHakukohdekoodinJaValintakoekoodienMukaan(
-            sanitizeKoodiUri(importData.getHakukohdekoodi().getKoodiUri()),
-            valintakoekoodiUrit.keySet());
-    LOG.info("Potentiaalisia valintaryhmiä {} kpl", valintaryhmat.size());
-    // Tarkistetaan valintaryhmät valintakoekoodien osalta.
-    Iterator<Valintaryhma> iterator = valintaryhmat.iterator();
-    while (iterator.hasNext()) {
-      Valintaryhma r = iterator.next();
-      Map<String, Integer> valintaryhmanValintakoekoodiUrit = new HashMap<String, Integer>();
-      List<Valintakoekoodi> valintakoekoodit = valintakoekoodiDAO.findByValintaryhma(r.getOid());
-      // Lasketaan valintakoekoodien esiintymät valintaryhmässä
-      for (Valintakoekoodi k : valintakoekoodit) {
-        if (!valintaryhmanValintakoekoodiUrit.containsKey(k.getUri())) {
-          valintaryhmanValintakoekoodiUrit.put(k.getUri(), 0);
-        }
-        Integer esiintymat = valintaryhmanValintakoekoodiUrit.get(k.getUri()) + 1;
-        valintaryhmanValintakoekoodiUrit.put(k.getUri(), esiintymat);
-      }
-      if (!valintakoekoodiUrit.equals(valintaryhmanValintakoekoodiUrit)) {
-        iterator.remove();
-      }
-    }
-    LOG.info(
-        "Valintakoekoodifilterin jälkeen potentiaalisia valintaryhmiä {} kpl",
-        valintaryhmat.size());
-    // Filtteroinnin jälkeen pitäisi jäljellä olla toivottavasti enää yksi
-    // valintaryhmä. Jos valintaryhmiä on
-    // enemmän kuin yksi (eli valintaryhmien mallinnassa on ryssitty ja
-    // esim. sama hakukohdekoodi on usealla
-    // valintaryhmällä) tai jos valintaryhmiä on nolla kappaletta, lisätään
-    // importoitava hakukohde juureen (eli
-    // tämä metodi palauttaa nullin).
-    Valintaryhma valintaryhma = null;
-    if (valintaryhmat.size() == 1) {
-      String ryhmanHakuoid = valintaryhmat.get(0).getHakuoid();
-      if (!StringUtils.isBlank(ryhmanHakuoid) && !ryhmanHakuoid.equals(importData.getHakuOid())) {
-        LOG.info(
-            "Hakukohteelle ei pystytty määrittämään valintaryhmää. Potentiaalinen ryhmä löytyi, mutta haun oid ei täsmää.");
-      } else {
-        valintaryhma = valintaryhmat.get(0);
-        LOG.info("Hakukohteen tulisi olla valintaryhmän {} alla", valintaryhma.getOid());
-      }
-    } else if (valintaryhmat.size() > 1) {
-      List<Valintaryhma> filtered =
-          valintaryhmat.stream()
-              .filter(hakuoidFilter(importData.getHakuOid()))
-              .collect(Collectors.toList());
-      if (filtered.size() == 1) {
-        valintaryhma = filtered.get(0);
-        LOG.info("Hakukohteen tulisi olla valintaryhmän {} alla", valintaryhma.getOid());
-      } else {
-        // Testataan vielä hakuvuodella
-        final List<Valintaryhma> vuodenRyhmat =
-            valintaryhmat.stream()
-                .filter(
-                    v ->
-                        !StringUtils.isBlank(v.getHakuvuosi())
-                            && v.getHakuvuosi().equals(importData.getHakuVuosi()))
-                .collect(Collectors.toList());
-        if (vuodenRyhmat.size() == 1) {
-          valintaryhma = vuodenRyhmat.get(0);
-          LOG.info("Hakukohteen tulisi olla valintaryhmän {} alla", valintaryhma.getOid());
-        } else {
-          LOG.info(
-              "Hakukohteelle ei pystytty määrittämään valintaryhmää. Potentiaalisia valintaryhmiä on {} kpl. "
-                  + "Hakukohde lisätään juureen tai säilytetään vanhassa ryhmässä.",
-              valintaryhmat.size());
-        }
-      }
-    } else {
-      List<Valintaryhma> haunRyhmat = valintaryhmaDAO.readByHakuoid(importData.getHakuOid());
-      if (haunRyhmat.size() == 1) {
-        valintaryhma = haunRyhmat.get(0);
-        LOG.info("Hakukohteen tulisi olla valintaryhmän {} alla", valintaryhma.getOid());
-      } else {
-        LOG.info("Yhtään potentiaalista valintaryhmää ei löytynyt. Hakukohde lisätään juureen.");
-      }
-    }
-    return valintaryhma;
-  }
+            hakuOid, hakukohdekoodi, valintakoekoodit);
 
-  private Predicate<Valintaryhma> hakuoidFilter(String hakuoid) {
-    return v -> !StringUtils.isBlank(v.getHakuoid()) && v.getHakuoid().equals(hakuoid);
+    if (valintaryhmat.size() != 1) {
+      LOG.info(
+          "Haku {}, hakukohdekoodi {} ja valintakoekoodit {} eivät antaneet yksikäsitteistä valintaryhmää. Mahdolliset ryhmät {}.",
+          hakuOid,
+          hakukohdekoodi,
+          String.join(", ", valintakoekoodit),
+          valintaryhmat.stream().map(Valintaryhma::getOid).collect(Collectors.joining(", ")));
+      valintaryhmat = valintaryhmaDAO.readByHakuoid(hakuOid);
+    }
+
+    if (valintaryhmat.size() != 1) {
+      LOG.info(
+          "Haku {} ei antanut yksikäsitteistä valintaryhmää. Mahdolliset ryhmät {}.",
+          hakuOid,
+          valintaryhmat.stream().map(Valintaryhma::getOid).collect(Collectors.joining(", ")));
+      valintaryhmat = Collections.singletonList(null);
+    }
+
+    Valintaryhma valintaryhma = valintaryhmat.get(0);
+    if (valintaryhma == null) {
+      LOG.info("Hakukohteen {} tulisi olla juurivalintaryhmän alla.", hakukohdeOid);
+    } else {
+      LOG.info(
+          "Hakukohteen {} tulisi olla valintaryhmän {} alla.", hakukohdeOid, valintaryhma.getOid());
+    }
+
+    return valintaryhma;
   }
 
   @Override

--- a/valintaperusteet-service/src/test/java/fi/vm/sade/service/valintaperusteet/dao/ValintaryhmaDAOTest.java
+++ b/valintaperusteet-service/src/test/java/fi/vm/sade/service/valintaperusteet/dao/ValintaryhmaDAOTest.java
@@ -5,10 +5,8 @@ import static org.junit.Assert.assertEquals;
 import fi.vm.sade.service.valintaperusteet.annotation.DataSetLocation;
 import fi.vm.sade.service.valintaperusteet.listeners.ValinnatJTACleanInsertTestExecutionListener;
 import fi.vm.sade.service.valintaperusteet.model.Valintaryhma;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,41 +60,35 @@ public class ValintaryhmaDAOTest {
 
   @Test
   public void testHaeHakukohdekoodinOpetuskielikoodienJaValintakoekoodienMukaan() {
-    final String valintaryhmaOid1 = "oid44";
-    final String valintaryhmaOid2 = "oid45";
-
-    final String[] valintakoekoodiUrit = new String[] {"koekoodi2"};
-    final String hakukohdekoodiUri = "hakukohdekoodiuri11";
-
     List<Valintaryhma> valintaryhmat =
         valintaryhmaDAO.haeHakukohdekoodinJaValintakoekoodienMukaan(
-            hakukohdekoodiUri, Arrays.asList(valintakoekoodiUrit));
+            "hakuoid50", "hakukohdekoodiuri11", Collections.singleton("koekoodi2"));
 
-    assertEquals(2, valintaryhmat.size());
-
-    Collections.sort(
-        valintaryhmat,
-        new Comparator<Valintaryhma>() {
-          @Override
-          public int compare(Valintaryhma o1, Valintaryhma o2) {
-            return o1.getOid().compareTo(o2.getOid());
-          }
-        });
-
-    assertEquals(valintaryhmaOid1, valintaryhmat.get(0).getOid());
-    assertEquals(valintaryhmaOid2, valintaryhmat.get(1).getOid());
+    assertEquals(1, valintaryhmat.size());
+    assertEquals("oid44", valintaryhmat.get(0).getOid());
   }
 
   @Test
   public void testHaeHakukohdekoodinOpetuskielikoodienJaValintakoekoodienMukaan2() {
-    final String hakukohdekoodiUri = "hakukohdekoodiuri15";
-
     List<Valintaryhma> valintaryhmat =
         valintaryhmaDAO.haeHakukohdekoodinJaValintakoekoodienMukaan(
-            hakukohdekoodiUri, new ArrayList<String>());
+            "hakuoid50", "hakukohdekoodiuri15", new HashSet<>());
 
     assertEquals(1, valintaryhmat.size());
     assertEquals("oid50", valintaryhmat.get(0).getOid());
+  }
+
+  @Test
+  public void testHaeHakukohdekoodinOpetuskielikoodienJaValintakoekoodienMukaan3() {
+    HashSet<String> valintakoekoodit = new HashSet<>();
+    valintakoekoodit.add("koekoodi1");
+    valintakoekoodit.add("koekoodi2");
+    List<Valintaryhma> valintaryhmat =
+        valintaryhmaDAO.haeHakukohdekoodinJaValintakoekoodienMukaan(
+            "hakuoid50", "hakukohdekoodiuri11", valintakoekoodit);
+
+    assertEquals(1, valintaryhmat.size());
+    assertEquals("oid45", valintaryhmat.get(0).getOid());
   }
 
   @Test

--- a/valintaperusteet-service/src/test/java/fi/vm/sade/service/valintaperusteet/service/HakukohdeImportServiceTest.java
+++ b/valintaperusteet-service/src/test/java/fi/vm/sade/service/valintaperusteet/service/HakukohdeImportServiceTest.java
@@ -21,7 +21,6 @@ import fi.vm.sade.service.valintaperusteet.listeners.ValinnatJTACleanInsertTestE
 import fi.vm.sade.service.valintaperusteet.model.HakukohdeViite;
 import fi.vm.sade.service.valintaperusteet.model.Hakukohdekoodi;
 import fi.vm.sade.service.valintaperusteet.model.ValinnanVaihe;
-import fi.vm.sade.service.valintaperusteet.model.Valintakoekoodi;
 import fi.vm.sade.service.valintaperusteet.model.Valintaryhma;
 import fi.vm.sade.service.valintaperusteet.model.Valintatapajono;
 import fi.vm.sade.service.valintaperusteet.service.impl.HakukohdeImportServiceImpl;
@@ -268,7 +267,7 @@ public class HakukohdeImportServiceTest {
 
     final String valintaryhmaOidAluksi = "oid40";
 
-    final String hakuOid = "hakuoid1";
+    final String hakuOid = "hakuoid5";
     final String hakukohdeOid = "oid14";
     final String hakukohdekoodiUri = "hakukohdekoodiuri5";
     {
@@ -336,7 +335,7 @@ public class HakukohdeImportServiceTest {
     // oikean valintaryhmän alla
     final String valintaryhmaOidAluksi = "oid40";
 
-    final String hakuOid = "hakuoid1";
+    final String hakuOid = "hakuoid4";
     final String hakukohdeOid = "oid14";
     final String hakukohdekoodiUri = "hakukohdekoodiuri6";
     {
@@ -405,15 +404,15 @@ public class HakukohdeImportServiceTest {
   @Test
   public void testKaksiValintaryhmaaSamoillaKoodeilla() {
     // Kannassa on kaksi valintaryhmää samoilla hakukohdekoodeilla, samoilla
-    // opetuskielikoodeilla ja samoilla
-    // valintakoekooddeilla varustettuna. Uuden hakukohteen tulisi valua
+    // opetuskielikoodeilla, samoilla
+    // valintakoekooddeilla ja samoilla hakuoideilla. Uuden hakukohteen tulisi valua
     // juureen, koska
     // valintaryhmää ei voida yksilöidä.
 
     final String valintaryhmaOid1 = "oid46";
     final String valintaryhmaOid2 = "oid47";
 
-    final String hakuOid = "hakuoid1";
+    final String hakuOid = "hakuoid2";
     final String hakukohdeOid = "uusihakukohdeoid";
     final String hakukohdekoodiUri = "hakukohdekoodiuri12";
 
@@ -466,13 +465,13 @@ public class HakukohdeImportServiceTest {
       assertNull(hakukohde.getValintaryhma());
     }
 
-    // Lisätään toiselle valintaryhmälle hakuvuosi ja katsotaan että hakukohde putoaa oikeaan
+    // Poistetaan toiselta valintaryhmältä hakuoidi ja katsotaan että hakukohde putoaa oikeaan
     // ryhmään
     {
       Valintaryhma valintaryhma2 = valintaryhmaService.readByOid(valintaryhmaOid2);
       ValintaperusteetModelMapper mapper = new ValintaperusteetModelMapper();
       ValintaryhmaCreateDTO dto = mapper.map(valintaryhma2, ValintaryhmaCreateDTO.class);
-      dto.setHakuvuosi("2013");
+      dto.setHakuoid(null);
       valintaryhmaService.update(valintaryhmaOid2, dto);
     }
 
@@ -482,7 +481,7 @@ public class HakukohdeImportServiceTest {
       HakukohdeViite hakukohde = hakukohdeViiteDAO.readByOid(hakukohdeOid);
       assertFalse(hakukohde.getManuaalisestiSiirretty());
       assertNotNull(hakukohde);
-      assertEquals(valintaryhmaOid2, hakukohde.getValintaryhma().getOid());
+      assertEquals(valintaryhmaOid1, hakukohde.getValintaryhma().getOid());
     }
   }
 
@@ -490,7 +489,7 @@ public class HakukohdeImportServiceTest {
   public void testPaivitaAloituspaikkojenLkm() {
     final String valintaryhmaOid = "oid48";
 
-    final String hakuOid = "hakuoid1";
+    final String hakuOid = "hakuoid3";
     final String hakukohdeOid = "uusihakukohdeoid";
     final String hakukohdekoodiUri = "hakukohdekoodiuri13";
 
@@ -550,7 +549,7 @@ public class HakukohdeImportServiceTest {
   public void testKKAlaPaivitaAloituspaikkojenLkm() {
     final String valintaryhmaOid = "oid48";
 
-    final String hakuOid = "hakuoid1";
+    final String hakuOid = "hakuoid3";
     final String hakukohdeOid = "uusihakukohdeoid";
     final String hakukohdekoodiUri = "hakukohdekoodiuri13";
 
@@ -603,55 +602,6 @@ public class HakukohdeImportServiceTest {
       Valintatapajono jono = jonot.get(0);
       assertNotNull(jono.getMasterValintatapajono());
       assertFalse(aloituspaikat == jono.getAloituspaikat().intValue());
-    }
-  }
-
-  @Test
-  public void testMelkeinSopivaValintaryhma() {
-    // Kannassa on valintaryhmä joka täsmää melkein importoitavaan
-    // hakukohteeseen. Ainoa ero on, että sama
-    // valintakoekoodi on lisätty valintaryhmälle kaksi kertaa.
-
-    final String valintaryhmaOid = "oid49";
-
-    final String hakuOid = "hakuoid1";
-    final String hakukohdeOid = "uusihakukohdeoid";
-    final String hakukohdekoodiUri = "hakukohdekoodiuri14";
-
-    {
-      assertNull(hakukohdeViiteDAO.readByOid(hakukohdeOid));
-
-      Hakukohdekoodi koodi = hakukohdekoodiDAO.readByUri(hakukohdekoodiUri);
-      assertNotNull(koodi);
-      List<Valintaryhma> valintaryhmas = valintaryhmaDAO.readByHakukohdekoodiUri(hakukohdekoodiUri);
-
-      assertEquals(1, valintaryhmas.size());
-      assertEquals(valintaryhmaOid, valintaryhmas.get(0).getOid());
-
-      Valintaryhma valintaryhma1 = valintaryhmaService.readByOid(valintaryhmaOid);
-      // assertTrue(valintaryhma1.getOpetuskielikoodit().size() == 1
-      // &&
-      // HakukohdeImportServiceImpl.Kieli.FI.getUri().equals(valintaryhma1.getOpetuskielikoodit().iterator().next().getUri()));
-
-      List<Valintakoekoodi> valintakoekoodit = valintaryhma1.getValintakoekoodit();
-      assertEquals(2, valintakoekoodit.size());
-      assertEquals(valintakoekoodit.get(0).getUri(), OLETUS_VALINTAKOEURI);
-      assertEquals(valintakoekoodit.get(1).getUri(), OLETUS_VALINTAKOEURI);
-    }
-
-    HakukohdeImportDTO importData = luoHakukohdeImportDTO(hakukohdeOid, hakuOid, hakukohdekoodiUri);
-    HakukohteenValintakoeDTO koe = new HakukohteenValintakoeDTO();
-    koe.setTyyppiUri("toinenkoodityyppiuri");
-    koe.setOid("toinenoid");
-    importData.getValintakoe().add(koe);
-
-    hakukohdeImportService.tuoHakukohde(importData);
-
-    {
-      HakukohdeViite hakukohde = hakukohdeViiteDAO.readByOid(hakukohdeOid);
-      assertFalse(hakukohde.getManuaalisestiSiirretty());
-      assertNotNull(hakukohde);
-      assertNull(hakukohde.getValintaryhma());
     }
   }
 

--- a/valintaperusteet-service/src/test/resources/test-data.xml
+++ b/valintaperusteet-service/src/test/resources/test-data.xml
@@ -415,33 +415,33 @@
 
     <valintaryhma id="35" version="0" oid="oid35" nimi="Valintaryhma 35"/>
     <valintaryhma id="36" version="0" oid="oid36" nimi="Valintaryhma 36"/>
-    <valintaryhma id="37" version="0" oid="oid37" nimi="Valintaryhma 37"/>
+    <valintaryhma id="37" version="0" oid="oid37" hakuoid="uusiHakuOid" nimi="Valintaryhma 37"/>
 
     <valintaryhma id="38" version="0" oid="oid38" nimi="Valintaryhma 38"/>
 
     <valintaryhma id="39" version="0" oid="oid39" nimi="Valintaryhma 39"/>
 
-    <valintaryhma id="40" version="0" oid="oid40" nimi="Valintaryhma 40"/>
+    <valintaryhma id="40" version="0" oid="oid40" hakuoid="hakuoid4" nimi="Valintaryhma 40"/>
 
-    <valintaryhma id="41" version="0" oid="oid41" nimi="Valintaryhma 41"/>
+    <valintaryhma id="41" version="0" oid="oid41" hakuoid="hakuoid1" nimi="Valintaryhma 41"/>
 
     <valintaryhma id="42" version="0" oid="oid42" nimi="Valintaryhma 42"/>
 
     <valintaryhma id="43" version="0" oid="oid43" nimi="Valintaryhma 43"/>
 
-    <valintaryhma id="44" version="0" oid="oid44" nimi="Valintaryhma 44"/>
+    <valintaryhma id="44" version="0" oid="oid44" hakuoid="hakuoid50" nimi="Valintaryhma 44"/>
 
-    <valintaryhma id="45" version="0" oid="oid45" nimi="Valintaryhma 45"/>
+    <valintaryhma id="45" version="0" oid="oid45" hakuoid="hakuoid50" nimi="Valintaryhma 45"/>
 
-    <valintaryhma id="46" version="0" oid="oid46" nimi="Valintaryhma 46"/>
+    <valintaryhma id="46" version="0" oid="oid46" hakuoid="hakuoid2" nimi="Valintaryhma 46"/>
 
-    <valintaryhma id="47" version="0" oid="oid47" nimi="Valintaryhma 47"/>
+    <valintaryhma id="47" version="0" oid="oid47" hakuoid="hakuoid2" nimi="Valintaryhma 47"/>
 
-    <valintaryhma id="48" version="0" oid="oid48" nimi="Valintaryhma 48"/>
+    <valintaryhma id="48" version="0" oid="oid48" hakuoid="hakuoid3" nimi="Valintaryhma 48"/>
 
     <valintaryhma id="49" version="0" oid="oid49" nimi="Valintaryhma 49"/>
 
-    <valintaryhma id="50" version="0" oid="oid50" nimi="Valintaryhma 50"/>
+    <valintaryhma id="50" version="0" oid="oid50" hakuoid="hakuoid50" nimi="Valintaryhma 50"/>
 
     <valintaryhma id="51" version="0" oid="oid51" nimi="Valintaryhma 51"/>
 


### PR DESCRIPTION
Etsi valintaryhmiä vain niistä ryhmistä jotka ovat hakukohteen haun
valintaryhmän aliryhmiä.

Valitse valintaryhmä vain jos sille on määritelty tasan samat valintakoekoodit
kuin hakukohteelle.

Liitä hakukohde haun valintaryhmään jos tarkempaa ryhmää ei löydy.