### PR TITLE
OY-5275 Tietoturvapäivitykset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
           cache: 'maven'
 
       - name: Deploy jar library
-        #if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         shell: bash
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
           cache: 'maven'
 
       - name: Deploy jar library
-        if: github.ref == 'refs/heads/master'
+        #if: github.ref == 'refs/heads/master'
         shell: bash
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}

--- a/ovara-valintaperusteet/pom.xml
+++ b/ovara-valintaperusteet/pom.xml
@@ -4,12 +4,12 @@
 
     <groupId>fi.vm.sade.valintaperusteet</groupId>
     <artifactId>ovara-valintaperusteet</artifactId>
-    <version>7.1-SNAPSHOT</version>
+    <version>7.1.1-SNAPSHOT</version>
 
     <parent>
         <artifactId>valintaperusteet</artifactId>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
-        <version>7.1-SNAPSHOT</version>
+        <version>7.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>fi.vm.sade.valintaperusteet</groupId>
             <artifactId>valintaperusteet-service</artifactId>
-            <version>7.1-SNAPSHOT</version>
+            <version>7.1.1-SNAPSHOT</version>
         </dependency>
 
         <!-- flyway -->

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.9</version>
     </parent>
 
     <groupId>fi.vm.sade.valintaperusteet</groupId>
     <artifactId>valintaperusteet</artifactId>
-    <version>7.1-SNAPSHOT</version>
+    <version>7.1.1-SNAPSHOT</version>
 
     <name>Valintaperusteet</name>
     <packaging>pom</packaging>
@@ -219,28 +219,8 @@
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback.access</groupId>
-                <artifactId>tomcat</artifactId>
-                <version>2.0.3</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>tomcat-servlet-api</artifactId>
-                <version>10.1.34</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>tomcat-coyote</artifactId>
-                <version>10.1.34</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>tomcat-catalina</artifactId>
-                <version>10.1.34</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>10.1.34</version>
+                <artifactId>logback-access-tomcat</artifactId>
+                <version>2.0.6</version>
             </dependency>
             <dependency>
                 <groupId>com.zaxxer</groupId>
@@ -250,7 +230,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.7.4</version>
+                <version>42.7.7</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -319,15 +299,15 @@
                 <scope>compile</scope>
             </dependency>
             <dependency>
-                <groupId>com.querydsl</groupId>
+                <groupId>io.github.openfeign.querydsl</groupId>
                 <artifactId>querydsl-jpa</artifactId>
-                <version>5.1.0</version>
+                <version>5.6.1</version>
                 <classifier>jakarta</classifier>
             </dependency>
             <dependency>
-                <groupId>com.querydsl</groupId>
+                <groupId>io.github.openfeign.querydsl</groupId>
                 <artifactId>querydsl-apt</artifactId>
-                <version>5.1.0</version>
+                <version>5.6.1</version>
                 <classifier>jakarta</classifier>
                 <scope>provided</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -579,19 +579,12 @@
 
     <repositories>
         <repository>
-            <releases>
-                <enabled>false</enabled>
-                <updatePolicy>always</updatePolicy>
-                <checksumPolicy>warn</checksumPolicy>
-            </releases>
             <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-                <checksumPolicy>warn</checksumPolicy>
+                <enabled>false</enabled>
             </snapshots>
-            <id>oph-sade-artifactory</id>
-            <name>oph-sade-artifactory-snapshots</name>
-            <url>https://artifactory.opintopolku.fi/artifactory/oph-sade-snapshot-local</url>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
         </repository>
         <repository>
             <releases>
@@ -617,81 +610,6 @@
             </snapshots>
             <id>oph-sade-artifactory-snapshots</id>
             <url>https://artifactory.opintopolku.fi/artifactory/oph-sade-snapshot-local</url>
-        </repository>
-        <repository>
-            <id>repository.jboss.org</id>
-            <name>JBoss Repository</name>
-            <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
-        </repository>
-        <repository>
-            <id>vaadin-addons</id>
-            <name>Vaadin addons</name>
-            <url>https://artifactory.opintopolku.fi/artifactory/vaadin-addons</url>
-        </repository>
-        <repository>
-            <id>com.springsource.repository.bundles.release</id>
-            <name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Releases</name>
-            <url>https://artifactory.opintopolku.fi/artifactory/springsource-ebr/</url>
-        </repository>
-        <repository>
-            <id>com.springsource.repository.bundles.external</id>
-            <name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
-            <url>https://artifactory.opintopolku.fi/artifactory/spring-ebr/</url>
-        </repository>
-        <repository>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>com.springsource.repository.maven.snapshot</id>
-            <name>SpringSource Enterprise Bundle Maven Repository - SpringSource Snapshot Releases</name>
-            <url>https://artifactory.opintopolku.fi/artifactory/com.springsource.repository.maven.snapshot/</url>
-        </repository>
-        <repository>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>com.springsource.repository.maven.milestone</id>
-            <name>Spring Framework Maven Milestone Releases (Maven Central Format)</name>
-            <url>https://artifactory.opintopolku.fi/artifactory/com.springsource.repository.maven.milestone/</url>
-        </repository>
-        <repository>
-            <id>atomikos</id>
-            <name>Atomikos repository</name>
-            <url>https://artifactory.opintopolku.fi/artifactory/atomikos/</url>
-        </repository>
-        <repository>
-            <id>shibboleth</id>
-            <name>Shibboleth</name>
-            <url>https://artifactory.opintopolku.fi/artifactory/shibboleth/</url>
-        </repository>
-        <repository>
-            <id>libs-3rd-party</id>
-            <name>libs-3rd-party</name>
-            <url>https://artifactory.opintopolku.fi/artifactory/libs-3rd-party</url>
-        </repository>
-        <repository>
-            <id>bedatadriven</id>
-            <name>bedatadriven</name>
-            <url>https://artifactory.opintopolku.fi/artifactory/bedatadriven/</url>
-        </repository>
-        <repository>
-            <id>cpdetector</id>
-            <name>cpdetector</name>
-            <url>https://artifactory.opintopolku.fi/artifactory/cpdetector</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>central</id>
-            <name>Central Repository</name>
-            <url>https://repo.maven.apache.org/maven2</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.9</version>
+        <version>3.4.10</version>
     </parent>
 
     <groupId>fi.vm.sade.valintaperusteet</groupId>

--- a/valintaperusteet-api/pom.xml
+++ b/valintaperusteet-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>valintaperusteet</artifactId>
 		<groupId>fi.vm.sade.valintaperusteet</groupId>
-		<version>7.1-SNAPSHOT</version>
+		<version>7.1.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/valintaperusteet-domain/pom.xml
+++ b/valintaperusteet-domain/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
         <artifactId>valintaperusteet</artifactId>
-		<version>7.1-SNAPSHOT</version>
+		<version>7.1.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>valintaperusteet-domain</artifactId>
@@ -36,13 +36,13 @@
 			<artifactId>commons-lang</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.querydsl</groupId>
+			<groupId>io.github.openfeign.querydsl</groupId>
 			<artifactId>querydsl-apt</artifactId>
 			<classifier>jakarta</classifier>
 		</dependency>
 
 		<dependency>
-			<groupId>com.querydsl</groupId>
+			<groupId>io.github.openfeign.querydsl</groupId>
 			<artifactId>querydsl-jpa</artifactId>
 			<classifier>jakarta</classifier>
 		</dependency>
@@ -64,10 +64,10 @@
 					<!--generatedSourcesDirectory>target/generated-sources/java</generatedSourcesDirectory-->
 					<annotationProcessorPaths>
 						<path>
-							<groupId>com.querydsl</groupId>
+							<groupId>io.github.openfeign.querydsl</groupId>
 							<artifactId>querydsl-apt</artifactId>
 							<classifier>jakarta</classifier>
-							<version>5.1.0</version>
+							<version>5.6.1</version>
 						</path>
 						<path>
 							<groupId>jakarta.persistence</groupId>

--- a/valintaperusteet-laskenta/pom.xml
+++ b/valintaperusteet-laskenta/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
         <artifactId>valintaperusteet</artifactId>
-        <version>7.1-SNAPSHOT</version>
+        <version>7.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/valintaperusteet-service/pom.xml
+++ b/valintaperusteet-service/pom.xml
@@ -236,7 +236,7 @@
         <dependency>
             <groupId>fi.vm.sade.java-utils</groupId>
             <artifactId>opintopolku-user-details-service</artifactId>
-            <version>0.2.0-SNAPSHOT</version>
+            <version>0.5.3-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/valintaperusteet-service/pom.xml
+++ b/valintaperusteet-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fi.vm.sade.valintaperusteet</groupId>
         <artifactId>valintaperusteet</artifactId>
-        <version>7.1-SNAPSHOT</version>
+        <version>7.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -71,7 +71,7 @@
 
         <!--External -->
         <dependency>
-            <groupId>com.querydsl</groupId>
+            <groupId>io.github.openfeign.querydsl</groupId>
             <artifactId>querydsl-jpa</artifactId>
             <classifier>jakarta</classifier>
         </dependency>
@@ -80,7 +80,7 @@
             <artifactId>cglib-nodep</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.querydsl</groupId>
+            <groupId>io.github.openfeign.querydsl</groupId>
             <artifactId>querydsl-apt</artifactId>
             <classifier>jakarta</classifier>
             <scope>provided</scope>
@@ -116,7 +116,7 @@
         <!-- LOG -->
         <dependency>
             <groupId>ch.qos.logback.access</groupId>
-            <artifactId>tomcat</artifactId>
+            <artifactId>logback-access-tomcat</artifactId>
         </dependency>
 
         <!--Hibernate & related -->

--- a/valintaperusteet-service/src/main/java/fi/vm/sade/service/valintaperusteet/config/SecurityConfiguration.java
+++ b/valintaperusteet-service/src/main/java/fi/vm/sade/service/valintaperusteet/config/SecurityConfiguration.java
@@ -60,8 +60,7 @@ public class SecurityConfiguration {
         environment.getProperty(
             "host.host-alb", environment.getRequiredProperty("host.host-virkailija"));
     CasAuthenticationProvider casAuthenticationProvider = new CasAuthenticationProvider();
-    casAuthenticationProvider.setUserDetailsService(
-        new OphUserDetailsServiceImpl(host, ConfigEnums.CALLER_ID.value()));
+    casAuthenticationProvider.setAuthenticationUserDetailsService(new OphUserDetailsServiceImpl());
     casAuthenticationProvider.setServiceProperties(serviceProperties());
     casAuthenticationProvider.setTicketValidator(ticketValidator());
     casAuthenticationProvider.setKey(environment.getRequiredProperty("cas-service.key"));


### PR DESCRIPTION
Spring Bootin patch-version päivitys ratkaisi monta ongelmaa jo itsessään.

Logbackin access-logien tomcat-paketti on vaihtanut nimeä. Paketti on siis sama, sille vain tehtiin patch-version päivitys. Spring Bootin ja tämän yhdistelmä päivitti kaikki logbackin riippuvuudet, joten alipaketit pystyi poistamaan dependency managementista.

Querydsl:ssä olevaa ongelmaa ei ilmeisestikään olla ratkaisemassa (https://avd.aquasec.com/nvd/2024/cve-2024-49203/). Sen ylläpito on muutenkin minimaalista nykyään. Querydsl:stä on tehty forkki, jota ylläpidetään aktiivisemmin (OpenFeign Querydsl). Tuossa forkissa on myös korjattu tuo tietoturvaongelma, joten vaihdetaan siihen forkkiin. Pitäisi olla täysin drop-in replacement, eikä ainakaan paikallisissa testeissä näkynyt virheitä vaihdon jälkeen.